### PR TITLE
fix: default compression is snappy

### DIFF
--- a/src/mnesia_rocksdb.erl
+++ b/src/mnesia_rocksdb.erl
@@ -1060,7 +1060,7 @@ default_open_opts() ->
          list_to_integer(get_env_default(
                            "ROCKSDB_WRITE_BUFFER_SIZE", "4194304"))}
       , {compression,
-         list_to_atom(get_env_default("ROCKSDB_COMPRESSION", "true"))}
+         list_to_atom(get_env_default("ROCKSDB_COMPRESSION", "snappy"))}
       , {use_bloomfilter, true}
     ].
 


### PR DESCRIPTION
In some OS'es, like Archlinux, an unknown compression method such as
the previous default `"true"` was causing the compression algorithm to
be `zstd`, which is not available in the way we build
`erlang_rocksdb`.

Since `snappy` is always included, we can just set the default to
that.

```
2022-08-15T10:40:44.819754-03:00 [error] crasher: initial call: mnesia_rocksdb:init/1, pid: <0.2393.0>, registered_name: [], error: {{badmatch,{error,{db_open,"Invalid argument: Compression type ZSTD is not linked with the binary."}}},[{mnesia_rocksdb,do_load_table,2,[{file,"/home/thales/dev/emqx/emqx/deps/mnesia_rocksdb/src/mnesia_rocksdb.erl"},{line,943}]},{mnesia_rocksdb,init,1,[{file,"/home/thales/dev/emqx/emqx/deps/mnesia_rocksdb/src/mnesia_rocksdb.erl"},{line,920}]},{gen_server,init_it,2,[{file,"gen_server.erl"},{line,423}]},{gen_server,init_it,6,[{file,"gen_server.erl"},{line,390}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}, ancestors: [mnesia_ext_sup,mnesia_sup,<0.2147.0>], message_queue_len: 0, messages: [], links: [<0.2150.0>], dictionary: [], trap_exit: true, status: running, heap_size: 1598, stack_size: 29, reductions: 454; neighbours:
```