### PR TITLE
chore: bump erlang-rocksdb to 1.7.2-emqx-7

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps,
  [
   {sext, "1.8.0"},
-  {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb.git", {tag, "1.7.2-emqx-6"}}}
+  {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb.git", {tag, "1.7.2-emqx-7"}}}
  ]}.
 
 {profiles,


### PR DESCRIPTION
Which includes fully OTP-25 compatible builds.