### PR TITLE
chore: bump erlang-rocksdb to 1.7.2-emqx-9

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps,
  [
   {sext, "1.8.0"},
-  {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb.git", {tag, "1.7.2-emqx-7"}}}
+  {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb.git", {tag, "1.7.2-emqx-9"}}}
  ]}.
 
 {profiles,


### PR DESCRIPTION
no functional changes, only extra binary packages