### PR TITLE
build: use default build flags for erlang-rocksdb

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,11 +1,4 @@
 %% -*- erlang-mode -*-
-case os:getenv("ERLANG_ROCKSDB_OPTS") of
-    false ->
-        true = os:putenv("ERLANG_ROCKSDB_OPTS", "-DWITH_BUNDLE_LZ4=ON");
-    _ ->
-        %% If manually set, we assume it's throught through
-        skip
-end.
 case os:getenv("DEBUG") of
     "true" ->
 	Opts = proplists:get_value(erl_opts, CONFIG, []),


### PR DESCRIPTION
Otherwise the put environment variable will cause trouble for subsequent build steps.
